### PR TITLE
fix(loader): make the GristApi object lazy

### DIFF
--- a/src/grist_loader/loader.py
+++ b/src/grist_loader/loader.py
@@ -16,8 +16,6 @@ from .models import GristModel
 
 logger = logging.getLogger(__name__)
 
-gristapi = GristApi(config=settings.GRIST_PYGRISTER_CONFIG)
-
 
 class GristLoader:
     model = None
@@ -34,7 +32,10 @@ class GristLoader:
                 "GristLoader model must be a subclass of GristModel"
             )
         if not isinstance(self.table, str):
-            raise ImproperlyConfigured("GristLoader table must be a str: it's the name of a Grist table")
+            raise ImproperlyConfigured(
+                "GristLoader table must be a str: it's the name of a Grist table"
+            )
+        self.gristapi = GristApi(config=settings.GRIST_PYGRISTER_CONFIG)
         self.current_obj = None
         self.current_row = None
 
@@ -114,8 +115,10 @@ class GristLoader:
         return False
 
     def load(self):
-        logger.debug(f"Loading table {self.table} into model {self.model._meta.model_name}")
-        status, rows = gristapi.list_records(self.table)
+        logger.debug(
+            f"Loading table {self.table} into model {self.model._meta.model_name}"
+        )
+        status, rows = self.gristapi.list_records(self.table)
         for row in rows:
             # check if all required cols do have a value
             # ignore the row if not

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,6 @@
 import pytest
 
-from grist_loader.loader import gristapi
+from grist_loader.loader import GristApi
 
 from .models import ModelA, ModelB
 from .grist import ModelALoader, ModelBLoader
@@ -21,10 +21,11 @@ def test_load_model_a(monkeypatch, model_a):
             {"id": 2, "col_a": "Other custom field a", "col_b": 47},
         ]
 
-    monkeypatch.setattr(gristapi, "list_records", mock_list_records)
+    loader = ModelALoader()
+    monkeypatch.setattr(loader.gristapi, "list_records", mock_list_records)
 
     # WHEN loading ModelA
-    ModelALoader().load()
+    loader.load()
 
     # THEN we have 2 ModelA
     # the existing one had its field_a updated
@@ -46,10 +47,11 @@ def test_load_model_b(monkeypatch, model_a, model_a_other):
             {"id": 1, "col_reference_to_a": model_a.pk, "col_references_to_a": ["L2", model_a.pk, model_a_other.pk]},
         ]
 
-    monkeypatch.setattr(gristapi, "list_records", mock_list_records)
+    loader = ModelBLoader()
+    monkeypatch.setattr(loader.gristapi, "list_records", mock_list_records)
 
     # WHEN loading ModelB
-    ModelBLoader().load()
+    loader.load()
 
     # THEN we have 1 ModelB
     # no new ModelA has vbeen created


### PR DESCRIPTION
Avoid API connection/auth at Django startup, when we don't know yet if it will be used. Plus, this allows future changes where each loader could have its own Grist configuration, if it happens to be useful.